### PR TITLE
按 4-agent 接入演练修流程逻辑五个洞

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -115,6 +115,7 @@ A Fact has two structural zones:
 | `state` | enum | Workflow state (§4.1) |
 | `epistemic_state` | enum | Trust state (§4.2) |
 | `claimed_by` | string \| null | Consumer that claimed (exclusive only) |
+| `claimed_at` | float \| null | Claim timestamp; used for claim-timeout reaping (§4.1) |
 | `resolved_at` | float \| null | Resolution timestamp |
 | `superseded_by` | string | Set when a newer fact supersedes this one |
 | `corroborations` | string[] | Consumers that have corroborated |
@@ -165,8 +166,15 @@ Tracks lifecycle. Explicit transitions driven by bus operations.
 | `published` → `resolved` | Direct resolution (broadcast only) |
 | `published` → `dead` | TTL expiry, no match |
 | `claimed` → `resolved` | RESOLVE by claimer |
-| `claimed` → `published` | RELEASE by claimer (returns to pool) |
-| `claimed` → `dead` | Claim timeout, consumer failure |
+| `claimed` → `published` | RELEASE by claimer, **or claim timeout** (returns to pool, re-dispatched) |
+| `claimed` → `dead` | Hard failure (not used by the current implementation; reserved) |
+
+**Claim timeout** — if a fact has been in `claimed` longer than the bus's
+configured `claimTimeoutSeconds` (default 600s = 10 min, §11), the bus
+auto-releases it back to `published` and re-dispatches it. This is the
+recovery path when a claimer crashes between CLAIM and RESOLVE. The bus
+excludes the previous claimer from the next dispatch round to prevent a
+crash-loop pinning the same fact.
 | `dead` → `published` | Administrative redispatch (OPTIONAL) |
 
 ### 4.2 Epistemic State
@@ -314,7 +322,7 @@ POST /facts
   "source_ant_id": "...", "token": "...",      // token optional
   "content_hash": "...",                       // empty string → bus computes
   "created_at": <unix-seconds>,
-  "mode": "broadcast" | "exclusive",
+  "mode": "broadcast" | "exclusive",           // default: broadcast
   "priority": 0..7, "ttl_seconds": <int>,
   "parent_fact_id": "...", "subject_key": "...", "supersedes": "...",
   "semantic_kind": "...", "confidence": 0..1,
@@ -338,13 +346,21 @@ Any check failing rejects the publish.
 ### 7.3 Query (the polling cursor)
 
 ```
-GET /facts?fact_type=...&state=...&since_sequence=N&limit=50
+GET /facts?fact_type=...&state=...&claimed_by=...&source_ant_id=...&since_sequence=N&limit=50
 → JSON array, sorted by sequence_number ascending when since_sequence is set
    Response header: X-Antlegion-Max-Sequence: <max sequence returned>
 ```
 
 Clients drive their own polling loop by passing the previous response's max
 sequence back as `since_sequence`. This is the canonical pattern.
+
+`fact_type` accepts a **glob** pattern (`*` matches any substring, `?` matches
+one character). `bug.*` matches `bug.found`, `bug.fixed`, etc. A pattern with
+no glob characters is matched exactly.
+
+`claimed_by` filters facts currently held by a specific consumer. Useful for
+a daemon that wants to find its own orphaned claims on restart:
+`GET /facts?state=claimed&claimed_by=my-daemon-1`.
 
 ```
 GET /facts/cursor
@@ -585,6 +601,8 @@ signatures unverifiable across restarts.
 | Parameter | Default | Source |
 |---|:---:|---|
 | Default fact TTL | 86400s (24h) | Implementation choice; was 1800s before, raised for client polling |
+| Default fact `mode` | `broadcast` | §7.2 — most LLM-published facts are observations, not tasks |
+| Claim timeout | 600s (10 min) | §4.1 — claimed facts auto-released back to `published` |
 | Causation depth limit | 16 | §9.5 |
 | Consensus / refutation quorum | 2 | §4.2 |
 | Dedup window | 10s | §9.5 |

--- a/antlegion-bus/src/engine/BusEngine.ts
+++ b/antlegion-bus/src/engine/BusEngine.ts
@@ -31,7 +31,7 @@ import {
 } from "../types/protocol.js";
 import { transition, canTransition } from "./WorkflowStateMachine.js";
 import { recomputeEpistemic } from "./EpistemicStateMachine.js";
-import { evaluateFilter, arbitrate } from "./FilterEngine.js";
+import { evaluateFilter, arbitrate, globMatch } from "./FilterEngine.js";
 import { PublishGate, applyAging } from "./FlowControl.js";
 import { recordEvent, shouldAcceptPublication, ErrorEvent, type ErrorEventValue } from "./ReliabilityManager.js";
 import { computeContentHash } from "./ContentHasher.js";
@@ -129,6 +129,7 @@ export class BusEngine {
         if (existing) {
           existing.state = fact.state;
           existing.claimed_by = fact.claimed_by;
+          existing.claimed_at = fact.claimed_at;
           existing.resolved_at = fact.resolved_at;
         }
       } else if (event === "release") {
@@ -136,6 +137,7 @@ export class BusEngine {
         if (existing) {
           existing.state = "published";
           existing.claimed_by = null;
+          existing.claimed_at = null;
         }
       } else if (event === "redispatch") {
         const existing = this.facts.get(fact.fact_id);
@@ -184,7 +186,8 @@ export class BusEngine {
       recovered++;
     }
 
-    // Rebuild active claims
+    // Rebuild active claims + restore sequence counter so new facts don't collide
+    let maxSeq = 0;
     for (const fact of this.facts.values()) {
       if (
         fact.claimed_by &&
@@ -195,10 +198,12 @@ export class BusEngine {
           (this.activeClaims.get(fact.claimed_by) ?? 0) + 1,
         );
       }
+      if (fact.sequence_number > maxSeq) maxSeq = fact.sequence_number;
     }
+    this.sequenceCounter = maxSeq;
 
     if (recovered > 0) {
-      console.log(`[BusEngine] Recovered ${recovered} fact events from store`);
+      console.log(`[BusEngine] Recovered ${recovered} fact events from store (head_sequence=${maxSeq})`);
     }
   }
 
@@ -249,12 +254,34 @@ export class BusEngine {
 
   private expirationTick(): void {
     const now = Date.now() / 1000;
+    const claimTimeout = this.config.bus.claimTimeoutSeconds;
     for (const fact of this.facts.values()) {
       if (
         (fact.state === "published" || fact.state === "matched") &&
         now > fact.created_at + fact.ttl_seconds
       ) {
         this.markDead(fact, "ttl_expired");
+        continue;
+      }
+
+      // Claim timeout: release stale claims back to the pool so they can be
+      // re-dispatched. Without this, a crashed claimer pins a fact in
+      // `claimed` until TTL — undesirable when TTL is hours/days.
+      if (
+        fact.state === "claimed" &&
+        fact.claimed_at != null &&
+        now > fact.claimed_at + claimTimeout
+      ) {
+        const claimer = fact.claimed_by;
+        if (claimer) {
+          const claims = this.activeClaims.get(claimer) ?? 0;
+          if (claims > 0) this.activeClaims.set(claimer, claims - 1);
+        }
+        transition(fact, "published");
+        fact.claimed_by = null;
+        fact.claimed_at = null;
+        this.store.append(fact, "release", { releaser: "bus:claim_timeout" });
+        this.dispatchFact(fact, claimer ? new Set([claimer]) : undefined);
       }
     }
   }
@@ -315,6 +342,11 @@ export class BusEngine {
 
   private nextSequence(): number {
     return ++this.sequenceCounter;
+  }
+
+  /** Current max assigned sequence number (== count of accepted publishes since boot, plus recovered ones). */
+  headSequence(): number {
+    return this.sequenceCounter;
   }
 
   private computeSignature(fact: Fact): string {
@@ -540,6 +572,7 @@ export class BusEngine {
     // Atomic: single tick, no await
     transition(fact, "claimed");
     fact.claimed_by = antId;
+    fact.claimed_at = Date.now() / 1000;
     this.activeClaims.set(antId, (this.activeClaims.get(antId) ?? 0) + 1);
     this.store.append(fact, "claim", { claimer: antId });
 
@@ -671,6 +704,7 @@ export class BusEngine {
 
     transition(fact, "published");
     fact.claimed_by = null;
+    fact.claimed_at = null;
 
     this.store.append(fact, "release", { releaser: antId });
     this.recordActivity(antId, "release", factId, fact.fact_type);
@@ -691,14 +725,22 @@ export class BusEngine {
     fact_type?: string;
     state?: FactState;
     source_ant_id?: string;
+    claimed_by?: string;
     limit?: number;
   }): Fact[] {
     const limit = opts?.limit ?? 100;
+    const hasGlob = opts?.fact_type && /[*?]/.test(opts.fact_type);
     const results: Fact[] = [];
     for (const fact of this.facts.values()) {
-      if (opts?.fact_type && fact.fact_type !== opts.fact_type) continue;
+      if (opts?.fact_type) {
+        const matches = hasGlob
+          ? globMatch(opts.fact_type, fact.fact_type)
+          : fact.fact_type === opts.fact_type;
+        if (!matches) continue;
+      }
       if (opts?.state && fact.state !== opts.state) continue;
       if (opts?.source_ant_id && fact.source_ant_id !== opts.source_ant_id) continue;
+      if (opts?.claimed_by && fact.claimed_by !== opts.claimed_by) continue;
       results.push(fact);
     }
     return results.sort((a, b) => b.created_at - a.created_at).slice(0, limit);

--- a/antlegion-bus/src/engine/FilterEngine.ts
+++ b/antlegion-bus/src/engine/FilterEngine.ts
@@ -34,7 +34,7 @@ function createMatchResult(): MatchResult {
 }
 
 /** Simple glob matcher (supports * and ?). */
-function globMatch(pattern: string, text: string): boolean {
+export function globMatch(pattern: string, text: string): boolean {
   const regex = new RegExp(
     "^" +
       pattern

--- a/antlegion-bus/src/server/app.ts
+++ b/antlegion-bus/src/server/app.ts
@@ -69,7 +69,10 @@ export function createApp(config?: Partial<BusConfig>) {
       domain_tags: body.domain_tags ?? [],
       need_capabilities: body.need_capabilities ?? [],
       priority: body.priority ?? 3,
-      mode: body.mode ?? "exclusive",
+      // Default to broadcast — most LLM-published facts are observations meant
+      // for shared context, not exclusive tasks. Callers wanting exclusive
+      // semantics must opt in.
+      mode: body.mode ?? "broadcast",
       source_ant_id: body.source_ant_id,
       created_at: body.created_at ?? Date.now() / 1000,
       ttl_seconds: body.ttl_seconds ?? 86400,
@@ -91,6 +94,7 @@ export function createApp(config?: Partial<BusConfig>) {
     const factType = c.req.query("fact_type");
     const state = c.req.query("state") as FactState | undefined;
     const sourceAntId = c.req.query("source_ant_id");
+    const claimedBy = c.req.query("claimed_by");
     const limit = parseInt(c.req.query("limit") ?? "100", 10);
     const sinceSequence = c.req.query("since_sequence");
     const sinceSeq = sinceSequence ? parseInt(sinceSequence, 10) : undefined;
@@ -99,6 +103,7 @@ export function createApp(config?: Partial<BusConfig>) {
       fact_type: factType,
       state,
       source_ant_id: sourceAntId,
+      claimed_by: claimedBy,
       limit: sinceSeq != null ? 10_000 : limit,
     });
 
@@ -116,8 +121,9 @@ export function createApp(config?: Partial<BusConfig>) {
 
   app.get("/facts/cursor", (c) => {
     const stats = engine.getStats() as { facts: { total: number } };
-    const all = engine.queryFacts({ limit: 1 });
-    const head = all.length > 0 ? all[0].sequence_number : 0;
+    // Use the engine's monotonic sequence counter, not "newest by created_at"
+    // (createdAt can be client-supplied and isn't strictly monotonic).
+    const head = engine.headSequence();
     return c.json({ head_sequence: head, total: stats.facts.total });
   });
 
@@ -404,6 +410,7 @@ function factToResponse(fact: Fact): Record<string, unknown> {
     created_at: fact.created_at,
     ttl_seconds: fact.ttl_seconds,
     claimed_by: fact.claimed_by,
+    claimed_at: fact.claimed_at,
     effective_priority: fact.effective_priority,
     causation_depth: fact.causation_depth,
     causation_chain: fact.causation_chain,

--- a/antlegion-bus/src/types/protocol.ts
+++ b/antlegion-bus/src/types/protocol.ts
@@ -149,6 +149,7 @@ export interface Fact {
   state: FactState;
   epistemic_state: EpistemicState;
   claimed_by: string | null;
+  claimed_at: number | null;
   resolved_at: number | null;
   effective_priority: number | null;
   sequence_number: number;
@@ -193,6 +194,7 @@ export function createFact(overrides: Partial<Fact> = {}): Fact {
     state: "created",
     epistemic_state: "asserted",
     claimed_by: null,
+    claimed_at: null,
     resolved_at: null,
     effective_priority: null,
     sequence_number: 0,
@@ -472,6 +474,7 @@ export interface BusConfig {
   bus: {
     maxCausationDepth: number;
     defaultTtlSeconds: number;
+    claimTimeoutSeconds: number;
     gcRetainResolvedSeconds: number;
     gcRetainDeadSeconds: number;
     gcMaxFacts: number;
@@ -501,6 +504,7 @@ export const DEFAULT_CONFIG: BusConfig = {
   bus: {
     maxCausationDepth: 16,
     defaultTtlSeconds: 86400,
+    claimTimeoutSeconds: 600,
     gcRetainResolvedSeconds: 86400,
     gcRetainDeadSeconds: 86400,
     gcMaxFacts: 10000,

--- a/antlegion-bus/test/bus-engine.test.ts
+++ b/antlegion-bus/test/bus-engine.test.ts
@@ -20,6 +20,7 @@ function makeEngine() {
     bus: {
       maxCausationDepth: 16,
       defaultTtlSeconds: 300,
+      claimTimeoutSeconds: 600,
       gcRetainResolvedSeconds: 600,
       gcRetainDeadSeconds: 3600,
       gcMaxFacts: 10000,
@@ -426,6 +427,86 @@ describe("BusEngine", () => {
   // -----------------------------------------------------------------------
   // Admin
   // -----------------------------------------------------------------------
+
+  describe("Claim timeout", () => {
+    it("releases stale claims back to published when claim timeout elapses", () => {
+      const shortEngine = new BusEngine({
+        data: { dir: TEST_DIR + "-claim-to" },
+        server: { port: 0, host: "127.0.0.1" },
+        bus: {
+          maxCausationDepth: 16,
+          defaultTtlSeconds: 300,
+          claimTimeoutSeconds: 1,
+          gcRetainResolvedSeconds: 600,
+          gcRetainDeadSeconds: 3600,
+          gcMaxFacts: 10000,
+          replayOnReconnect: 50,
+        },
+        flow: {
+          dedupeWindowSeconds: 10,
+          rateLimitCapacity: 100,
+          rateLimitRefillRate: 100,
+          circuitBreakerWindowSeconds: 5,
+          circuitBreakerThreshold: 1000,
+        },
+        trust: { consensusQuorum: 2, refutationQuorum: 2 },
+      });
+
+      try {
+        const f = publishableFact({ mode: "exclusive" });
+        shortEngine.publishFact(f);
+        const [ok] = shortEngine.claimFact(f.fact_id, "crashed-worker");
+        expect(ok).toBe(true);
+        expect(shortEngine.getFact(f.fact_id)?.state).toBe("claimed");
+        expect(shortEngine.getFact(f.fact_id)?.claimed_at).not.toBeNull();
+
+        // Backdate claimed_at past the timeout window.
+        const fact = shortEngine.getFact(f.fact_id)!;
+        fact.claimed_at = Date.now() / 1000 - 5;
+
+        // Drive the expirationTick via the public claim-of-self pathway:
+        // simpler — invoke the private tick by re-claiming with the same ant
+        // would not help; instead, advance a clock or just sleep and let the
+        // 10s interval fire. For unit-test speed we call the engine's reaper
+        // via a brief sleep + reading state. Use a small sleep so the actual
+        // interval timer (10s) doesn't fire, and instead manually trigger.
+        (shortEngine as unknown as { expirationTick: () => void }).expirationTick();
+
+        const after = shortEngine.getFact(f.fact_id)!;
+        expect(after.state).toBe("published");
+        expect(after.claimed_by).toBeNull();
+        expect(after.claimed_at).toBeNull();
+      } finally {
+        shortEngine.shutdown();
+        rmSync(TEST_DIR + "-claim-to", { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe("Glob query", () => {
+    it("queryFacts matches glob patterns in fact_type", () => {
+      engine.publishFact(publishableFact({ fact_type: "bug.found" }));
+      engine.publishFact(publishableFact({ fact_type: "bug.fixed" }));
+      engine.publishFact(publishableFact({ fact_type: "deploy.started" }));
+
+      expect(engine.queryFacts({ fact_type: "bug.*" }).length).toBe(2);
+      expect(engine.queryFacts({ fact_type: "*.found" }).length).toBe(1);
+      expect(engine.queryFacts({ fact_type: "bug.found" }).length).toBe(1);
+      expect(engine.queryFacts({ fact_type: "nomatch.*" }).length).toBe(0);
+    });
+
+    it("queryFacts filters by claimed_by", () => {
+      const f1 = publishableFact({ fact_type: "task.a", mode: "exclusive" });
+      const f2 = publishableFact({ fact_type: "task.b", mode: "exclusive" });
+      engine.publishFact(f1);
+      engine.publishFact(f2);
+      engine.claimFact(f1.fact_id, "worker-a");
+      engine.claimFact(f2.fact_id, "worker-b");
+
+      expect(engine.queryFacts({ claimed_by: "worker-a" }).length).toBe(1);
+      expect(engine.queryFacts({ claimed_by: "worker-a" })[0].fact_id).toBe(f1.fact_id);
+    });
+  });
 
   describe("Admin", () => {
     it("runs GC", () => {

--- a/antlegion-bus/test/http-api.test.ts
+++ b/antlegion-bus/test/http-api.test.ts
@@ -110,6 +110,10 @@ describe("HTTP API", () => {
       payload: { key: "value" },
       source_ant_id: ant_id,
       token,
+      // Default to exclusive in the test helper because most existing tests
+      // claim/resolve. Individual tests that want broadcast override via
+      // factOverrides.
+      mode: "exclusive",
       ...factOverrides,
     });
     return { antId: ant_id, token, factRes: factRes as any, status };

--- a/antlegion-mcp/README.md
+++ b/antlegion-mcp/README.md
@@ -80,24 +80,37 @@ The bus does not push events to MCP clients. Each client decides its own
 cadence:
 
 ```
-cursor = 0
 loop:
-  result = antlegion_query(since_sequence=cursor, limit=50)
+  result = antlegion_query(limit=50)           # since_sequence defaults to the persisted cursor
   for fact in result.facts:
       decide what to do
-  cursor = result.next_cursor
   sleep(your_interval)
 ```
 
 For a Claude Code session, the "loop" is the human typing. For a daemon, it
 is a real `setInterval`. The bus does not care.
 
+### Cursor persistence
+
+The adapter persists the last-seen sequence number to
+`~/.antlegion/cursor-<ANTLEGION_AGENT_NAME>.json`. This means:
+
+- `antlegion_query` calls **automatically advance** the cursor across restarts.
+- Cron-driven Codex / one-shot Claude invocations don't re-scan history from 0.
+- To scan from the beginning anyway, pass `since_sequence: 0` explicitly.
+
+### Glob queries
+
+`antlegion_query({ fact_type: "bug.*" })` matches any fact_type with that
+prefix. The bus supports `*` (any substring) and `?` (one character). A
+pattern with no glob characters is matched exactly.
+
 ## Environment variables
 
 | Variable | Default | Purpose |
 |---|---|---|
 | `ANTLEGION_BUS_URL` | `http://localhost:28080` | Bus REST endpoint. |
-| `ANTLEGION_AGENT_NAME` | `mcp-<pid>` | Used to derive a stable synthetic ant identity (`mcp:<name>`). Set this per client (e.g. `claude-code`, `cursor`) so facts and claims carry a meaningful provenance. |
+| `ANTLEGION_AGENT_NAME` | `<hostname>-<pid>` | Used directly as `source_ant_id` on every operation. Set this per client (e.g. `claude-code`, `cursor`) for readable provenance. If unset, the default uniquely identifies each process so two windows/machines don't collide. |
 
 ## Identity model
 

--- a/antlegion-mcp/src/index.ts
+++ b/antlegion-mcp/src/index.ts
@@ -19,21 +19,72 @@ import {
   ListToolsRequestSchema,
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { hostname } from "node:os";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 const BUS_URL = (process.env.ANTLEGION_BUS_URL ?? "http://localhost:28080").replace(/\/$/, "");
-const AGENT_NAME = process.env.ANTLEGION_AGENT_NAME ?? `mcp-client-${process.pid}`;
+
+// Identity:
+// - If ANTLEGION_AGENT_NAME is explicitly set, use it verbatim. The user takes
+//   responsibility for collision avoidance (e.g. setting it to "claude-code").
+// - Otherwise auto-derive a name that won't collide between hosts / windows /
+//   CI runs: <hostname>-<pid>. This is what gets sent as source_ant_id to
+//   every bus operation.
+const AGENT_NAME =
+  process.env.ANTLEGION_AGENT_NAME ?? `${hostname()}-${process.pid}`;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Bus client
 //
-// We use a stable synthetic ant_id derived from AGENT_NAME and never register
-// with the bus. The protocol accepts publish/claim/resolve from unregistered
-// ant_ids (the bus simply skips reliability tracking for them). This keeps the
-// bus from accumulating one phantom ant per Claude Code / Cursor restart.
+// We use AGENT_NAME directly as the source_ant_id and never register with the
+// bus. The protocol accepts publish/claim/resolve from unregistered ant_ids
+// (the bus simply skips reliability tracking for them). This keeps the bus
+// from accumulating one phantom ant per Claude Code / Cursor restart.
 // ─────────────────────────────────────────────────────────────────────────────
 
 const SYNTHETIC_ANT_ID = AGENT_NAME;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cursor persistence
+//
+// The bus is poll-only and clients drive their own scan loop. To make this
+// useful across process restarts (cron-driven Codex, Claude Code reopen, etc.)
+// we persist the last seen sequence_number per AGENT_NAME under
+//   ~/.antlegion/cursor-<AGENT_NAME>.json
+// On startup the file is loaded; every successful query updates it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const CURSOR_DIR = join(homedir(), ".antlegion");
+const CURSOR_FILE = join(CURSOR_DIR, `cursor-${encodeURIComponent(AGENT_NAME)}.json`);
+
 let lastSeenSequence = 0;
+try {
+  if (existsSync(CURSOR_FILE)) {
+    const raw = readFileSync(CURSOR_FILE, "utf-8");
+    const parsed = JSON.parse(raw) as { last_sequence?: number };
+    if (typeof parsed.last_sequence === "number" && Number.isFinite(parsed.last_sequence)) {
+      lastSeenSequence = parsed.last_sequence;
+    }
+  }
+} catch {
+  // Corrupt or unreadable cursor file is non-fatal; start from 0.
+}
+
+function persistCursor(seq: number): void {
+  try {
+    if (!existsSync(CURSOR_DIR)) mkdirSync(CURSOR_DIR, { recursive: true });
+    writeFileSync(
+      CURSOR_FILE,
+      JSON.stringify({ last_sequence: seq, agent_name: AGENT_NAME, updated_at: new Date().toISOString() }, null, 2),
+      "utf-8",
+    );
+  } catch {
+    // Cursor persistence failure is non-fatal; we just lose the optimization
+    // on next restart.
+  }
+}
 
 async function busPost(path: string, body: Record<string, unknown>): Promise<unknown> {
   const res = await fetch(`${BUS_URL}${path}`, {
@@ -113,15 +164,23 @@ async function toolPublish(args: {
 }
 
 async function toolQuery(args: QueryArgs) {
+  // Default to the persisted cursor so repeated queries (and cron-driven
+  // restarts) automatically advance instead of re-reading from 0. Callers
+  // who want to scan the entire history pass since_sequence: 0 explicitly.
+  const effectiveSince = args.since_sequence ?? lastSeenSequence;
+
   const qs = new URLSearchParams();
   if (args.fact_type) qs.set("fact_type", args.fact_type);
   if (args.state) qs.set("state", args.state);
-  if (args.since_sequence != null) qs.set("since_sequence", String(args.since_sequence));
+  if (effectiveSince > 0) qs.set("since_sequence", String(effectiveSince));
   qs.set("limit", String(args.limit ?? 50));
   const facts = (await busGet(`/facts?${qs.toString()}`)) as FactSummary[];
 
   const maxSeq = facts.reduce((m, f) => Math.max(m, f.sequence_number), lastSeenSequence);
-  if (maxSeq > lastSeenSequence) lastSeenSequence = maxSeq;
+  if (maxSeq > lastSeenSequence) {
+    lastSeenSequence = maxSeq;
+    persistCursor(maxSeq);
+  }
 
   return {
     count: facts.length,


### PR DESCRIPTION
## 来源

4 个独立 agent 分别扮演 Claude Code / Cursor / Codex CLI / 自写守护进程，对照原始设计意图把整套 MCP 接入流程跑了一遍，交叉报告出 5 个真实 bug。本 PR 一并修。

## 修复清单

### 1. glob 查询是骗人的 (Cursor agent)

```typescript
// 之前
if (opts?.fact_type && fact.fact_type !== opts.fact_type) continue;  // 严格等于
// 之后
const hasGlob = opts?.fact_type && /[*?]/.test(opts.fact_type);
if (opts?.fact_type) {
  const matches = hasGlob ? globMatch(opts.fact_type, fact.fact_type) : fact.fact_type === opts.fact_type;
  if (!matches) continue;
}
```

`antlegion_query({fact_type: "bug.*"})` 现在能正确匹配 `bug.found` / `bug.fixed` 等。复用 FilterEngine 已有的 globMatch（导出）。

### 2. 无 claim 超时 (daemon agent — 最深的洞)

PROTOCOL.md §4.1 状态机明确写 `claimed → dead (Claim timeout, ant failure)`，但代码里 `expirationTick` 完全不碰 `claimed`。**守护进程崩溃后 fact 永远卡在 claimed**。

修：
- `Fact` 新增 `claimed_at: number | null`，`claimFact` 时设置，release/resolve 时清除
- `BusConfig.bus.claimTimeoutSeconds`（默认 600s = 10min）
- `expirationTick` 扫 claimed facts，超时后回 `published` 状态 + 重新派发（排除原 claimer 防 crash-loop）
- 状态机改为 `claimed → published`（自动恢复），不是 `claimed → dead`（丢任务）
- PROTOCOL.md §4.1 状态机表同步更新

### 3. AGENT_NAME 默认值撞车 (3 个 agent 都发现)

之前 MCP adapter 默认 `mcp-client-${pid}`，但 QUICKSTART 推荐用户设 `ANTLEGION_AGENT_NAME=claude-code` 之类的常量名。**两个 Claude Code 窗口 / 两个 Cursor 实例 / 三个 CI runner 共享同一个 AGENT_NAME → 全部映射到同一个 source_ant_id**，claim 自己 publish 的 fact、审计链塌缩。

修：默认改为 `${hostname()}-${pid}`。显式设置的 AGENT_NAME 仍然原样使用（用户取舍）。

### 4. cursor 在进程内存里 (Codex CLI / cron 完全 broken)

之前 `lastSeenSequence` 是模块级变量，进程退出就丢。**Cron 每 5 分钟 `codex run` 重启进程，每次都从 sequence=0 重读全量历史**。

修：MCP adapter 启动时读 `~/.antlegion/cursor-${AGENT_NAME}.json`，每次 query 推进 cursor 后立刻持久化。`toolQuery` 在 caller 没传 `since_sequence` 时默认用持久化的 cursor。

### 5. mode 默认值不一致 (daemon agent)

MCP adapter 默认 `broadcast`，bus app.ts 默认 `exclusive`。同一份 payload 走两条路径行为不同。

修：bus 端默认改为 `broadcast` 与 MCP 对齐。理由：大多数 LLM publish 的 fact 是 observation，不是 task。需要 exclusive 必须显式声明。

## 顺手修的几个小问题 (daemon agent 发现)

| 问题 | 修法 |
|---|---|
| daemon 重启后无法扫自己的孤儿 claim | 加 `GET /facts?claimed_by=<id>` 查询参数 |
| `GET /facts/cursor` 用 created_at 排序找最新（不严格单调） | 改用 BusEngine 自己的 `headSequence()` |
| 重启后 sequenceCounter 不恢复，新 fact 与历史碰撞 | `recoverFromStore` 末尾扫所有 fact 取 max |
| 客户端看不到 `claimed_at` | `factToResponse` 暴露该字段 |

## 验证

- ✅ bus `tsc` build
- ✅ mcp `tsc` build
- ✅ bus `npm test`: **171 通过 / 4 失败**（同样的 ContentHasher Python-hash drift 旧债，与本 PR 无关）
- ✅ 比上轮多 3 个测试：claim timeout、glob query、claimed_by 过滤
- ✅ 端到端 smoke（实启 bus + curl 全链路）：

```
=== glob query bug.* ===     matched=2: ['bug.found', 'bug.fixed']   ✓
=== exact query bug.found === matched=1: ['bug.found']               ✓
=== claimed_by filter ===     matched=1: claim_at present            ✓
=== /facts/cursor ===         {"head_sequence":2,"total":2}          ✓
=== mode default ===          {"mode":"broadcast", ...}              ✓
```

## 体量

9 文件，+251 / -23（净增 228 行）。多出来的主要是协议文档（PROTOCOL.md）、新增测试用例、和 MCP adapter 的 cursor 持久化代码。


---
_Generated by [Claude Code](https://claude.ai/code/session_012fBiTcG25veAgm5qiosLeF)_