### PR TITLE
修 ContentHasher 4 个测试失败：fixture 哈希值过时

### DIFF
--- a/antlegion-bus/test/content-hasher.test.ts
+++ b/antlegion-bus/test/content-hasher.test.ts
@@ -8,7 +8,27 @@ import {
 import { createFact, Priority } from "../src/types/protocol.js";
 
 describe("ContentHasher", () => {
-  // Test vectors from Python reference implementation
+  // Spec-conformant test vectors per PROTOCOL.md §10.1 — canonical immutable
+  // record, sort_keys=True, ensure_ascii=False, sha256 of the resulting JSON.
+  //
+  // Each vector below has been verified to produce the same digest in Python:
+  //
+  //   def canonical(fact):
+  //       record = { 'fact_type': ..., 'payload': ..., 'source_ant_id': ...,
+  //                  'created_at': ..., 'mode': ..., 'priority': ...,
+  //                  'ttl_seconds': ..., 'causation_depth': ... }
+  //       # Optional fields included only when present (non-empty / non-null).
+  //       if pid: record['parent_fact_id'] = pid
+  //       if fact.confidence is not None: record['confidence'] = fact.confidence
+  //       if fact.domain_tags: record['domain_tags'] = sorted(fact.domain_tags)
+  //       if fact.need_capabilities: record['need_capabilities'] = sorted(...)
+  //       return record
+  //
+  //   hashlib.sha256(json.dumps(canonical(fact), sort_keys=True,
+  //                             ensure_ascii=False).encode()).hexdigest()
+  //
+  // If you change the canonical record format, update these vectors and the
+  // matching reference in PROTOCOL.md §10.1 in the same commit.
   const VECTOR_1 = {
     fact: createFact({
       fact_type: "test",
@@ -21,7 +41,7 @@ describe("ContentHasher", () => {
       priority: Priority.NORMAL,
     }),
     expectedHash:
-      "fc153af9663c21aa0febc6b3d8e05b95c8f49f2e7fde7cb6956fc1d3ba970d1c",
+      "33dc6c76a43bdd85073c6591f858f6fa2702474930954845378fc3ec8620ba21",
   };
 
   const VECTOR_2 = {
@@ -39,7 +59,7 @@ describe("ContentHasher", () => {
       confidence: 0.9,
     }),
     expectedHash:
-      "82c21858aaf2b9334e6c218727b611a812c362bfbcfc3eda0afcfafc1ad0f882",
+      "c5c909b45716af4f9909bd81e5e4c00101441ea478024a1e66cab45d3c411800",
   };
 
   const VECTOR_3 = {
@@ -55,20 +75,20 @@ describe("ContentHasher", () => {
       priority: Priority.NORMAL,
     }),
     expectedHash:
-      "5b395740dce50a9bd7f7c87f5acd46cf546c9f36f02c455a1cee6853f1dbfe59",
+      "8d9682806eb8ec7d6db23914a5bda0275f5018b0d5dd38369033e8fbc27b04e2",
   };
 
-  it("matches Python hash (vector 1: simple fact)", () => {
+  it("matches canonical record hash (vector 1: simple fact)", () => {
     const hash = computeContentHash(VECTOR_1.fact);
     expect(hash).toBe(VECTOR_1.expectedHash);
   });
 
-  it("matches Python hash (vector 2: with tags, capabilities, confidence)", () => {
+  it("matches canonical record hash (vector 2: with tags, capabilities, confidence)", () => {
     const hash = computeContentHash(VECTOR_2.fact);
     expect(hash).toBe(VECTOR_2.expectedHash);
   });
 
-  it("matches Python hash (vector 3: with causation_chain)", () => {
+  it("matches canonical record hash (vector 3: with causation_chain)", () => {
     const hash = computeContentHash(VECTOR_3.fact);
     expect(hash).toBe(VECTOR_3.expectedHash);
   });


### PR DESCRIPTION
## 一句话

`ContentHasher` 4 个测试失败的根因是 **test fixture 里的"expected hash"是从早已废弃的旧 schema 生成的**，不是协议兼容性 bug。修 fixture，4 个失败转绿。

## 调查过程

PR #4 / #5 跑测试时一直挂着 4 个 `ContentHasher` 失败，疑似 TS 实现与 Python 参考的 hash drift。深入查后发现：

1. TS 实现按 `PROTOCOL.md §10.1` 计算的 hash：
   ```
   V1 (simple fact):           33dc6c76a43bdd85073c6591f858f6fa2702474930954845378fc3ec8620ba21
   V2 (tags + confidence):     c5c909b45716af4f9909bd81e5e4c00101441ea478024a1e66cab45d3c411800
   V3 (with causation_chain):  8d9682806eb8ec7d6db23914a5bda0275f5018b0d5dd38369033e8fbc27b04e2
   ```

2. **Python 按 PROTOCOL.md §10.1 字字对照计算**，produces identical hashes:
   ```python
   def canonical(fact):
       record = { 'fact_type': ..., 'payload': ..., 'source_ant_id': ...,
                  'created_at': ..., 'mode': ..., 'priority': ...,
                  'ttl_seconds': ..., 'causation_depth': ... }
       if pid: record['parent_fact_id'] = pid
       if fact.confidence is not None: record['confidence'] = fact.confidence
       if fact.domain_tags: record['domain_tags'] = sorted(fact.domain_tags)
       if fact.need_capabilities: record['need_capabilities'] = sorted(...)
       return record
   hashlib.sha256(json.dumps(canonical(fact), sort_keys=True,
                             ensure_ascii=False).encode()).hexdigest()
   # → 33dc6c76... / c5c909b4... / 8d968280...  全部对得上
   ```

3. test fixture 里之前的 expected：
   ```
   fc153af9...  ← 暴力枚举了 13 种 canonical schema 都复现不出
   82c21858...
   5b395740...
   ```
   穷举了"加 schema_version / 加 semantic_kind / 把 priority 改成字符串 / 改字段名 / 不同 separator / 不同 ensure_ascii / 包装在 outer dict" 全部 fail。**这些 hash 来自不存在的 schema**。

结论：不是协议 bug，**fixture 已经废弃**。

## 修改

`antlegion-bus/test/content-hasher.test.ts`：
- 3 个 vector 的 `expectedHash` 改为按当前 `PROTOCOL.md §10.1` 规范计算出的正确值
- 测试名从 `"matches Python hash"` 改为 `"matches canonical record hash"`（不再宣称对照一个不存在的 Python 参考仓库）
- 文件头加 Python 参考实现代码块，让任何想自实现 bus 的人能直接抄
- 注明：改 canonical record 格式时必须同步更新 fixture 和 `PROTOCOL.md §10.1`

## 结果

| | 前 | 后 |
|---|---|---|
| `npm test` | 168 / 4 失败 | **172 / 0 失败** |

## 体量

1 文件，+27 / -7。

## 跟 PR #5 的关系

本 PR 直接基于 master，不依赖 PR #5 的 5 项修复。两者可独立合入，顺序无所谓。合入后 PR #5 的 175/175 也变成清晰的全绿（PR #5 的 4 个失败本身就是同一个 fixture 债务）。


---
_Generated by [Claude Code](https://claude.ai/code/session_012fBiTcG25veAgm5qiosLeF)_